### PR TITLE
Update README for Dublin Core plug-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,31 @@
 # Dublin Core plug-in for DITA-OT HTML5
 
-DITA-OT plug-in to generate Dublin Core metadata in HTML5 output.
+This plug-in for [DITA Open Toolkit][1] extends the default `html5` transformation to generate additional [metadata][2].
+
+_(Up to version 3.5, DITA-OT includes the [Dublin Core™ Metadata Element Set][3] in both XHTML and HTML5 output.)_
+
+As of DITA-OT 3.6, Dublin Core metadata is no longer generated in the default HTML5 output. 
+
+This plug-in can be installed to add Dublin Core metadata to HTML5 if necessary.
 
 ## Compatibility
 
--   DITA-OT 3.6
+- DITA-OT 3.6
+
+## Installation
+
+Run the [plug-in installation command][4]:
+
+```shell
+dita install org.dita.html5.dublin-core
+```
 
 ## License
 
-The Dublin Core plug-in is licensed for use under the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).
+The Dublin Core plug-in is licensed for use under the [Apache License 2.0][5].
+
+[1]: https://github.com/dita-ot/dita-ot
+[2]: https://www.dublincore.org/resources/metadata-basics/
+[3]: https://dublincore.org/specifications/dublin-core/dcmi-terms
+[4]: https://www.dita-ot.org/dev/topics/plugins-installing.html
+[5]: https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
Dublin Core metadata support was extracted to this dedicated plug-in for DITA-OT 3.6 with https://github.com/dita-ot/dita-ot/pull/3595 and added to the registry with https://github.com/dita-ot/registry/pull/89.

This PR extends the [README](https://github.com/dita-ot/org.dita.html5.dublin-core/blob/master/README.md) stub with [additional information](https://github.com/dita-ot/org.dita.html5.dublin-core/blob/feature/update-readme/README.md) on the toolkit versions that provide this support by default, and how to install the plug-in if necessary.