### PR TITLE
Add spaces between publisher elements

### DIFF
--- a/xsl/dublin-core.xsl
+++ b/xsl/dublin-core.xsl
@@ -87,7 +87,13 @@ See the accompanying LICENSE file for applicable license.
 
   <!-- INTELLECTUAL PROPERTY: Publisher - prolog/publisher -->
   <xsl:template match="*[contains(@class,' topic/publisher ')]" mode="gen-metadata">
-    <meta name="DC.publisher" content="{normalize-space(.)}"/>
+    <xsl:variable name="text">
+      <xsl:for-each select="*">
+        <xsl:value-of select="normalize-space(.)"/>
+        <xsl:text> </xsl:text>
+      </xsl:for-each>
+    </xsl:variable>
+    <meta name="DC.publisher" content="{normalize-space($text)}"/>
   </xsl:template>
 
   <!-- Usage Rights - prolog/permissions -->


### PR DESCRIPTION
## Description

Dublin Core rendering  concatenates Organization and PrintLocation incorrectly if both elements are present. This PR adds a space between each element before normalizing whitespace.

## Motivation and Context

Consider the following `<Bookmap>` 

```xml
 <publisherinformation>
      <organization>Example Publishers</organization>
      <printlocation>Austin, TX</printlocation>
      <published>
        <publishtype value="general"/>
        <completed><year>1977</year></completed>
      </published>
    </publisherinformation>
```

This currently renders as:

```xml
<meta name="DC.publisher" content="Example PublishersAustin, TX1977">
```

It should render with a space between each element as:

```xml
<meta name="DC.publisher" content="Example Publishers Austin, TX 1977">
```

## How Has This Been Tested?
Manual testing

## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- (Remove inapplicable items) -->

- Bug fix

## Documentation and Compatibility
<!-- Describe whether your changes require updates to docs or user plug-ins. -->

- What documentation changes are needed for this feature?
  _(Provide links to existing documentation topics that will require updates)_
- Will this change affect backwards compatibility or other users' overrides?

## Checklist
<!-- Verify the following points before submitting the pull request. -->

- My code follows the code style of this project.
    -  <https://github.com/dita-ot/dita-ot/wiki/Java-Coding-Conventions>
    -  <https://github.com/dita-ot/dita-ot/wiki/XSLT-Coding-Conventions>
    -  <https://github.com/dita-ot/docs/wiki/coding-guidelines>
- I have updated the unit tests to reflect the changes in my code.

<!--
Before submitting, check the Preview tab above to verify the XML markup appears
correctly and remember you can edit the description later to add information.
-->
